### PR TITLE
chore: update git resolver revision after merge

### DIFF
--- a/integration-tests/pipelines/test-pipeline.yaml
+++ b/integration-tests/pipelines/test-pipeline.yaml
@@ -11,6 +11,6 @@ spec:
         - name: url 
           value: https://github.com/dheerajodha/the-mentalist-quiz
         - name: revision
-          value: "ui-tests"
+          value: main
         - name: pathInRepo
           value: integration-tests/task/test-task.yaml

--- a/integration-tests/task/test-task.yaml
+++ b/integration-tests/task/test-task.yaml
@@ -7,7 +7,7 @@ spec:
     - name: checkout-source
       image: alpine/git
       script: |
-        git clone -b ui-tests https://github.com/dheerajodha/the-mentalist-quiz.git /workspace
+        git clone https://github.com/dheerajodha/the-mentalist-quiz.git /workspace
     - name: list-files
       image: alpine
       script: |

--- a/integration-tests/test-pipelinerun.yaml
+++ b/integration-tests/test-pipelinerun.yaml
@@ -9,7 +9,7 @@ spec:
     - name: url 
       value: https://github.com/dheerajodha/the-mentalist-quiz
     - name: revision
-      value: ui-tests
+      value: main
     - name: pathInRepo
       value: integration-tests/pipelines/test-pipeline.yaml
   workspaces:


### PR DESCRIPTION
* This change is done because I couldnt have merged the PR#7 with the revision as "main".
* Why? because the Task would fail as Integration service would look for pipeline and task def in main branch, and UI test files doesnt exist there
* So running cypress command on main branch is wrong
* Due to this I merged the PR#7 as it was, and now opened this PR to update the revision back to "main" as now the main branch contains all the required files.
* This would get addressed by STONEINTG-1014