### PR TITLE
fix: Skip running clamav-scan task on PR and Push events

### DIFF
--- a/.tekton/the-mentalist-quiz-pull-request.yaml
+++ b/.tekton/the-mentalist-quiz-pull-request.yaml
@@ -395,7 +395,7 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values:
-        - "false"
+        - "true"
     - name: apply-tags
       params:
       - name: IMAGE

--- a/.tekton/the-mentalist-quiz-push.yaml
+++ b/.tekton/the-mentalist-quiz-push.yaml
@@ -392,7 +392,7 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values:
-        - "false"
+        - "true"
     - name: apply-tags
       params:
       - name: IMAGE


### PR DESCRIPTION
* this is to save the time during the demo